### PR TITLE
Add Etekcity VeSync Bulbs LED light

### DIFF
--- a/source/_integrations/vesync.markdown
+++ b/source/_integrations/vesync.markdown
@@ -2,6 +2,7 @@
 title: VeSync
 description: Instructions on how to set up VeSync switches, outlets, and fans within Home Assistant.
 ha_category:
+  - Light
   - Switch
   - Fan
 ha_release: 0.66
@@ -19,12 +20,17 @@ The devices must be added to the VeSync App before this integration can discover
 
 The following platforms are supported:
 
+- **light**
 - **switch**
 - **fan**
 
 ## Supported Devices
 
 This integration supports devices controllable by the VeSync App.  The following devices are supported by this integration:
+
+### Bulbs
+- Etekcity WiFi Dimmable LED Bulb (ESL100)
+- Etekcity WiFi Dimmable and Tunable White LED Bulb (ESL100CW)
 
 ### Plugs
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add Etekcity VeSync Bulbs LED light to homeassistant component


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/sdrapha/core/pull/1
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
